### PR TITLE
feat(findDupeTracks): check playlist permissions - hide delete button…

### DIFF
--- a/extensions/findDupeTracks/src/menu.tsx
+++ b/extensions/findDupeTracks/src/menu.tsx
@@ -913,10 +913,12 @@ const DuplicateRow = ({
   track,
   category,
   onDelete,
+  canAddTo,
 }: {
   track: DetailedTrack;
   category: DuplicateCategory;
   onDelete: (track: DetailedTrack) => void;
+  canAddTo: boolean;
 }) => (
   <div className={`duplicate-group__duplicate-item duplicate-group__item--${category}`}>
     <div className="duplicate-group__duplicate-info">
@@ -939,9 +941,13 @@ const DuplicateRow = ({
     </div>
     <div className="duplicate-group__actions">
       <TrackPlaybackControl duration={track.duration} uri={track.uri} />
-      <button className="duplicate-group__delete-button" onClick={() => onDelete(track)}>
-        Delete
-      </button>
+      {canAddTo ? (
+        <button className="duplicate-group__delete-button" onClick={() => onDelete(track)}>
+          Delete
+        </button>
+      ) : (
+        <span className="duplicate-group__no-permission">No permission</span>
+      )}
     </div>
   </div>
 );
@@ -952,12 +958,14 @@ const GroupSection = ({
   groups,
   onDelete,
   onDeleteAll,
+  canAddTo,
 }: {
   title: { label: string; tooltip: string };
   category: DuplicateCategory;
   groups: ReadonlyArray<DuplicateGroup>;
   onDelete: (cat: DuplicateCategory, t: DetailedTrack) => void;
   onDeleteAll: (cat: DuplicateCategory, trackCount: number) => void;
+  canAddTo: boolean;
 }) => {
   const totalDuplicates = groups.reduce((sum, g) => sum + g.duplicates.length, 0);
 
@@ -974,7 +982,7 @@ const GroupSection = ({
         </div>
         <div className="duplicate-group__heading-actions">
           <div className="duplicate-group__heading-length">{groups.length} found</div>
-          {totalDuplicates > 0 && (
+          {totalDuplicates > 0 && canAddTo && (
             <button
               className="duplicate-group__delete-all-button"
               onClick={() => onDeleteAll(category, totalDuplicates)}
@@ -992,6 +1000,7 @@ const GroupSection = ({
               key={g.mainTrack.uid}
             >
               <DuplicateRow
+                canAddTo={canAddTo}
                 category={category}
                 onDelete={(t) => onDelete(category, t)}
                 track={g.mainTrack}
@@ -1001,6 +1010,7 @@ const GroupSection = ({
                   <>
                     <div className="duplicate-group__duplicate-thread"></div>
                     <DuplicateRow
+                      canAddTo={canAddTo}
                       category={category}
                       key={dup.uid}
                       onDelete={(t) => onDelete(category, t)}
@@ -1180,6 +1190,7 @@ export function PlaylistDuplicateFinder({
 
               return (
                 <GroupSection
+                  canAddTo={currentPlaylist?.canAddTo === true}
                   category={cat}
                   groups={results[cat]}
                   key={cat}

--- a/extensions/findDupeTracks/src/styles.css
+++ b/extensions/findDupeTracks/src/styles.css
@@ -245,6 +245,14 @@
   filter: brightness(1.05);
 }
 
+.duplicate-group__no-permission {
+  padding: 6px 12px;
+  font-size: 0.85rem;
+  color: var(--fdp-subtext);
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .duplicate-settings__section {
   margin-bottom: 24px;
 }


### PR DESCRIPTION
# PR: Add Playlist Permission Check to Find Duplicate Tracks extension
## Summary
Added a permission check that verifies if the user has the right to delete tracks from the selected playlist before showing delete buttons.
## Extension
This PR applies to the **Find Duplicate Tracks** extension (`findDupeTracks`).
## Problem
When a user tries to delete duplicates from a playlist they don't have edit permissions for:
- The delete button appears (even though they can't delete)
- Clicking delete shows it as "removed" in the extension UI
- But the tracks remain in the actual Spotify playlist
- This creates confusion and a poor user experience
## Solution
The extension already fetches a list of playlists the user can edit (using `canAddTo` filter). Instead of making an extra API call to check permissions, we simply use this existing list to determine if the user has delete permissions:
- If the selected playlist is in the editable playlists list, show delete buttons
- If the selected playlist is not in the list (user lacks permission), show "No permission" text
- The **Delete All** button is also hidden when user lacks permission
## Implementation Details
The permission check is simplified by leveraging the existing playlist list:
- `useOwnedPlaylists()` already filters playlists with `canAddTo === true`
- `currentPlaylist` is determined by finding the selected URI in this filtered list
- If `currentPlaylist?.canAddTo` is not `true`, the user cannot delete tracks
- No additional API calls needed
## Files Changed
### `extensions/findDupeTracks/src/menu.tsx`
- Added `canAddTo` prop to `DuplicateRow` and `GroupSection` components
- Conditionally renders "No permission" text when user lacks delete permissions
- Added `canAddTo` check to hide **Delete All** button when user lacks permission
### `extensions/findDupeTracks/src/styles.css`
- Added `.duplicate-group__no-permission` styling for the "No permission" text
## Testing
1. Open Find Duplicate Tracks on a playlist you own
2. Verify delete buttons and Delete All button are visible and functional
3. Open Find Duplicate Tracks on a playlist you don't own
4. Verify "No permission" text appears instead of delete buttons
5. Verify **Delete All** button is hidden
6. Open Find Duplicate Tracks with owner permission.
7. Verify delete buttons and Delete All button are visible and functional

<img width="200" alt="No permission" src="https://github.com/user-attachments/assets/fafd9138-db31-4692-8a5d-a4e52026ae27" />
<img width="200" alt="Has permission" src="https://github.com/user-attachments/assets/a91ca744-d6b4-4db8-98c3-480903aeab04" />